### PR TITLE
Handle new modules

### DIFF
--- a/lib/git/create_action.js
+++ b/lib/git/create_action.js
@@ -25,15 +25,16 @@ var RD = require('../r10k/rundeck');
 var runCreate = function *(eventData, cbk) {
 
   var now = Date.now();
+  var new_content;
   var fullDeploymentNeeded = false;
   var gitdir = '/var/tmp/puppetfile_repo_'+now;
   var gitopts = { cwd: gitdir };
   var pfile = gitdir+'/Puppetfile';
   var branchName = eventData.branch;
   var moduleName = eventData.reponame;
+  var repoUrl = eventData.repourl;
   var rundeck_data = { "branch": branchName, "module": moduleName };
-  var module_regex_builder = '('+moduleName+'\\.git[\'"],\\s*:ref\\s*=>\\s*[\'"])[^\'"]+([\'"]\\s*)$';
-  var module_regex = new RegExp(module_regex_builder, 'gm');
+  var module_regex = new RegExp('('+repoUrl+'[\'"],\\s*:ref\\s*=>\\s*[\'"])([^\'"]+)([\'"]\\s*)$', 'gm');
 
   try {
 
@@ -65,19 +66,31 @@ var runCreate = function *(eventData, cbk) {
 
     // We update the reference for the module in the Puppetfile
     var content = yield fse.readFile(pfile, { encoding: 'utf-8' });
-    var moduleDefined = module_regex.test(content);
-
-    logger.debug('Is module '+moduleName+' defined in Puppetfile: '+moduleDefined);
+    // The following return an array with capturing groups if regex matches
+    var moduleDefined = module_regex.exec(content);
 
     if (!moduleDefined) {
-      // At the moment, we don't handle newly created modules not referenced in Puppetfile
-      throw new Error('NEW MODULE NOT REFERENCED IN PUPPETFILE: You need to add it manually to the Puppetfile');
-    }
 
-    var new_content = content.replace(module_regex, '$1'+branchName+'$2');
-    logger.debug(new_content);
-    yield fse.writeFile(pfile, new_content, { encoding: 'utf-8' });
-    logger.debug('Puppetfile updated');
+      // This module is not defined in Puppetfile so we need to build the string that will be appended to the Puppetfile
+      logger.info('Module '+moduleName+' is not yet referenced in Puppetfile. We need to update it.');
+
+      new_content = content+'\nmod "'+moduleName+'",\n  :git => "'+repoUrl+'",\n  :ref => "'+branchName+'"\n';
+      yield fse.writeFile(pfile, new_content, { encoding: 'utf-8' });
+
+      logger.info('New module '+moduleName+' successfully added to Puppetfile');
+
+    }
+    else {
+
+      // Module is defined in Puppetfile, we just need to update the ref
+      logger.info('Updating ref of module '+moduleName+' to '+branchName);
+      new_content = content.replace(module_regex, '$1'+branchName+'$3');
+      logger.debug(new_content);
+
+      yield fse.writeFile(pfile, new_content, { encoding: 'utf-8' });
+      logger.debug('Puppetfile updated');
+
+    }
 
     // Commiting changes
     yield* GU.commit(moduleName, branchName, gitopts);

--- a/lib/git/modify_action.js
+++ b/lib/git/modify_action.js
@@ -102,9 +102,6 @@ var runModify = function *(eventData, cbk) {
         yield fse.writeFile(pfile, new_content, { encoding: 'utf-8' });
         logger.debug('Puppetfile updated');
 
-        // Commiting changes
-        yield* GU.commit(moduleName, branchName, gitopts);
-
         pushNeeded = true;
 
       }
@@ -120,7 +117,10 @@ var runModify = function *(eventData, cbk) {
 
     if (pushNeeded) {
 
-      logger.debug('Branch '+branchName+' has been updated. Push required');
+      logger.debug('Branch '+branchName+' has been updated. Commit and push required');
+
+      // Commiting changes
+      yield* GU.commit(moduleName, branchName, gitopts);
 
       // Pushing changes to remote
       yield* GU.push(branchName, gitopts);

--- a/lib/git/modify_action.js
+++ b/lib/git/modify_action.js
@@ -19,23 +19,23 @@ var RD = require('../r10k/rundeck');
 
 
 /*
-  eventData: object containing the name of the branch, the name of the module and the type of event
+  eventData: object containing the name of the branch, the name of the module, the repo URL and the type of event
   cbk: represents the "done" callback used by kue to know when an error occured during job processing
 */
 var runModify = function *(eventData, cbk) {
 
   var now = Date.now();
+  var new_content;
   var fullDeploymentNeeded = false;
+  var pushNeeded = false;
   var gitdir = '/var/tmp/puppetfile_repo_'+now;
   var gitopts = { cwd: gitdir };
   var pfile = gitdir+'/Puppetfile';
   var branchName = eventData.branch;
   var moduleName = eventData.reponame;
+  var repoUrl = eventData.repourl;
   var rundeck_data = { "branch": branchName, "module": moduleName };
-  var module_regex_builder = '('+moduleName+'\\.git[\'"],\\s*:ref\\s*=>\\s*[\'"])[^\'"]+([\'"]\\s*)$';
-  var module_ref_regex_builder = '('+moduleName+'\\.git[\'"],\\s*:ref\\s*=>\\s*[\'"])'+branchName+'([\'"]\\s*)$';
-  var module_regex = new RegExp(module_regex_builder, 'gm');
-  var module_ref_regex = new RegExp(module_ref_regex_builder, 'gm');
+  var module_regex = new RegExp('('+repoUrl+'[\'"],\\s*:ref\\s*=>\\s*[\'"])([^\'"]+)([\'"]\\s*)$', 'gm');
 
   try {
 
@@ -57,55 +57,68 @@ var runModify = function *(eventData, cbk) {
         we need to tell r10k to update the whole environment. Otherwise, we'll simply update
         the module in the 'feature' environment.
       */
-      fullDeploymentNeeded = yield* GU.checkoutExisting(branchName, gitopts);
+      fullDeploymentNeeded = pushNeeded = yield* GU.checkoutExisting(branchName, gitopts);
     }
     else {
       // This case should never happen except when someone manually messed up with your Puppetfile
       yield* GU.checkoutNew(branchName, gitopts);
 
       // If the 'feature' branch doesn't exist on remote, we'll have to deploy the entire 'feature' environment
-      fullDeploymentNeeded = true;
+      fullDeploymentNeeded = pushNeeded = true;
     }
 
     // We update the reference for the module in the Puppetfile
     var content = yield fse.readFile(pfile, { encoding: 'utf-8' });
-    var moduleDefined = module_regex.test(content);
-
-    logger.debug('Is module '+moduleName+' defined in Puppetfile: '+moduleDefined);
+    // The following return an array with capturing groups if regex matches
+    var moduleDefined = module_regex.exec(content);
 
     if (!moduleDefined) {
-      // At the moment, we don't handle newly created modules not referenced in Puppetfile
-      throw new Error('NEW MODULE NOT REFERENCED IN PUPPETFILE: You need to add it manually to the Puppetfile');
-    }
 
-    /*
-      Module ref should already be pointing to "feature" branch as it's a "modify" event.
-      But if it's not the case for some reason, we have to update ref accordingly like we do in the "create" event.
-    */
-    var isRefOK = module_ref_regex.test(content);
+      // This module is not defined in Puppetfile so we need to build the string that will be appended to the Puppetfile
+      logger.info('Module '+moduleName+' is not yet referenced in Puppetfile. We need to update it.');
 
-    if (!isRefOK) {
-
-      logger.debug('Reference of module '+moduleName+' is not pointing to branch '+branchName+' for some reason. Updating it');
-      var new_content = content.replace(module_regex, '$1'+branchName+'$2');
-      logger.debug(new_content);
-
+      new_content = content+'\nmod "'+moduleName+'",\n  :git => "'+repoUrl+'",\n  :ref => "'+branchName+'"\n';
       yield fse.writeFile(pfile, new_content, { encoding: 'utf-8' });
-      logger.debug('Puppetfile updated');
 
-      // Commiting changes
-      yield* GU.commit(moduleName, branchName, gitopts);
+      logger.info('New module '+moduleName+' successfully added to Puppetfile');
 
+      pushNeeded = true;
+
+    }
+    else {
+
+      /*
+        Module exists in Puppetfile so ref should already be pointing to "feature" branch as it's a "modify" event.
+        But if it's not the case for some reason, we have to update ref accordingly like we do in the "create" event.
+      */
+
+      // moduleDefined[2] contains the name of the ref present in the Puppetfile
+      if ((moduleDefined[2] !== branchName)) {
+
+        logger.debug('Reference of module '+moduleName+' is not pointing to branch '+branchName+' for some reason. Updating it');
+        new_content = content.replace(module_regex, '$1'+branchName+'$3');
+        logger.debug(new_content);
+
+        yield fse.writeFile(pfile, new_content, { encoding: 'utf-8' });
+        logger.debug('Puppetfile updated');
+
+        // Commiting changes
+        yield* GU.commit(moduleName, branchName, gitopts);
+
+        pushNeeded = true;
+
+      }
     }
 
     /*
       Push only if needed, that is:
-        - when there were changes merged from the 'production' branch to the 'feature' branch
+        - when the module were not defined in the Puppetfile for the current branch
+        - or when there were changes merged from the 'production' branch to the 'feature' branch
         - or when the module ref was updated (see above)
         - or when both occured
     */
 
-    if (!isRefOK || fullDeploymentNeeded) {
+    if (pushNeeded) {
 
       logger.debug('Branch '+branchName+' has been updated. Push required');
 

--- a/lib/gitlabHandler.js
+++ b/lib/gitlabHandler.js
@@ -13,19 +13,20 @@ var detectEvent = function(payload) {
   return new Promise(function(resolve, reject) {
 
     if (!payload) {
-      reject('No JSON payload to process');
+      return reject('No JSON payload to process');
     }
     else {
       var reponame = payload.repository.name;
+      var repourl = payload.repository.git_ssh_url;
       var ref = payload.ref.split('/');
       var refType = ref[1];
       var branch = ref[2];
       var created = /^0+$/.test(payload.before);
       var deleted = /^0+$/.test(payload.after);
-      var eventInfo = { "reponame": reponame, "branch": branch };
+      var eventInfo = { "reponame": reponame, "branch": branch, "repourl": repourl };
 
       if (refType !== 'heads') {
-        reject('A reference of type "'+refType+'" was passed but we only handle "heads" reference type');
+        return reject('A reference of type "'+refType+'" was passed but we only handle "heads" reference type');
       }
       else {
         if (created) {
@@ -33,13 +34,18 @@ var detectEvent = function(payload) {
         }
         else if (deleted) {
           // Don't process any deletion of the production branch. Too risky for now.
-          (branch == 'production') ? reject('Deletion of the golden "production" branch is not allowed at the moment') : eventInfo.type = 'deleteEvent';
+          if (branch === 'production') {
+            return reject('Deletion of the golden "production" branch is not allowed at the moment');
+          }
+          else {
+            eventInfo.type = 'deleteEvent';
+          }
         }
         else if (!created && !deleted) {
           eventInfo.type = 'modifyEvent';
         }
 
-        resolve(eventInfo);
+        return resolve(eventInfo);
       }
     }
 

--- a/lib/kueUtils.js
+++ b/lib/kueUtils.js
@@ -19,7 +19,9 @@ var queueName = 'r10k';
 var createJob = function(eventInfo) {
   return new Promise(function(resolve, reject) {
 
-    if (!eventInfo) reject('No event data passed to job creation process');
+    if (!eventInfo.reponame || !eventInfo.branch || !eventInfo.repourl || !eventInfo.type) {
+      return reject('Job data sent to Redis is not correctly formatted. Either "reponame", "branch", "repourl" or "type" properties is not present');
+    }
 
     // Create the job in queue named 'r10k'
     var job = queue.create(queueName, eventInfo);
@@ -31,7 +33,7 @@ var createJob = function(eventInfo) {
     */
     job.attempts(1).removeOnComplete(true).save(function(err) {
       // If queueing the job in redis failed, pass the error to the promise
-      (err) ? reject(err) : resolve(job.id);
+      return (err) ? reject(err) : resolve(job.id);
     });
   });
 };
@@ -73,12 +75,7 @@ var processJob = function() {
   // Process jobs in Redis queue
   queue.process('r10k', function (job, done) {
 
-    if (!job.data.reponame || !job.data.branch || !job.data.type) {
-      return done(new Error('Job data sent to Redis is not correctly formatted. Either "reponame", "branch" or "type" properties is not present'));
-    }
-
     logger.info('Processing Redis task with ID '+job.id);
-
     logger.debug('Job data: '+JSON.stringify(job.data));
 
     switch (job.data.type) {


### PR DESCRIPTION
This PR attends to handle new modules not yet referenced in the Puppetfile. In this case, the app is now able to add the new modules definition to the Puppetfile (it's appended at the end of the file). The format is as follows:

mod "module_name",
  :git => "git_ssh_url",
  :ref => "branch_name"
